### PR TITLE
SC.ChildArray expects wrong signature for arrayObserver callback

### DIFF
--- a/lib/system/child_array.js
+++ b/lib/system/child_array.js
@@ -248,7 +248,7 @@ SC.ChildArray = SC.Object.extend(SC.Enumerable, SC.Array, SC.MutableEnumerable, 
 
     this.arrayContentWillChange(0, oldLen, newLen);
     this._prevChildren = children;
-    this._childrenContentDidChange(0, oldLen, newLen);
+    this._childrenContentDidChange(children, 0, oldLen, newLen);
 
     return this;
   },
@@ -263,7 +263,7 @@ SC.ChildArray = SC.Object.extend(SC.Enumerable, SC.Array, SC.MutableEnumerable, 
     @param {Number} value
     @param {Number} rev
   */
-  _childrenContentDidChange: function(start, removedCount, addedCount) {
+  _childrenContentDidChange: function(content, start, removedCount, addedCount) {
     this._records = null ; // clear cache
     this.arrayContentDidChange(start, removedCount, addedCount);
   },


### PR DESCRIPTION
It looks like this got broken by a change to the arrayObserver API.
