### PR TITLE
Make RecordAttributes cacheable

### DIFF
--- a/lib/attributes/record_attribute.js
+++ b/lib/attributes/record_attribute.js
@@ -312,9 +312,6 @@ SC.RecordAttribute = SC.Object.extend(
   /** @private - Make this look like a property so that `get()` will call it. */
   isProperty: YES,
 
-  /** @private - Make this look cacheable */
-  isCacheable: YES,
-
   /** @private - needed for KVO `property()` support */
   dependentKeys: [],
 
@@ -336,7 +333,7 @@ SC.RecordAttribute = SC.Object.extend(
     var attr = this;
     var ret  = SC.computed(function(key, value) {
       return attr.call(this, key, value);
-    });
+    }).cacheable();
     ret.attr = attr;
     return ret ;
   }


### PR DESCRIPTION
RecordAttributes are not cacheable, despite having some code that
looks like it was originally intended to make them so.  This has a
noticeable performance impact, especially for Dates, which are
relatively expensive to parse.
