### PR TITLE
specify the gems source to allow installing them

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+source "http://rubygems.org"
+
 gem "sproutcore", :git => "https://github.com/wycats/abbot-from-scratch.git"
 gem "uglifier", "1.0.0"
 gem "execjs", "1.2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ GIT
     sproutcore (0.0.1)
 
 GEM
+  remote: http://rubygems.org/
   specs:
     execjs (1.2.0)
       multi_json (~> 1.0)


### PR DESCRIPTION
In order to properly run bundle install, we need to specify the gems source.
