### PR TITLE
Nested relations are broken if key name does not match name of property.

### DIFF
--- a/packages/sproutcore-datastore/lib/system/record.js
+++ b/packages/sproutcore-datastore/lib/system/record.js
@@ -858,7 +858,7 @@ SC.Record = SC.Object.extend(
     if (value instanceof SC.Record) {
       childRecord = value;
     } else {
-      recordType = this._materializeNestedRecordType(value, key);
+      recordType = this._materializeNestedRecordType(value, path);
       childRecord = this.createNestedRecord(recordType, value);
     }
 


### PR DESCRIPTION
If the name of the property on the parent object is different than the 'key_name' of the relationship. getting any attribute on the related objects dies with: "SC.Child: Error during transform: Invalid record type."
